### PR TITLE
Added option for sequential local search

### DIFF
--- a/Tutorials/Rule_Inference_With_ScBONITA.ipynb
+++ b/Tutorials/Rule_Inference_With_ScBONITA.ipynb
@@ -43,6 +43,7 @@
     "1. condaEnv: conda environment to be activated in the generated sbatch scripts, if generateSbatch is True. Default = scBonita\n",
     "1. pythonVersion: Python version to be used in the generated sbatch scripts, if generateSbatch is True. Default = python3.6\n",
     "1. sampleCells: If True, scBonita will use a representative set of samples to infer rules. This is automatically done if the maxSamples parameter exceeds 15000, in order to reduce memory usage. Default=False\n",
+    "1. parallelSearch: If True, scBonita will use a parallelized local search to speed up the rule inference for large networks (with ~ 100 nodes or more). We suggest setting this to False for smaller networks or for KEGG networks, to reduce memory overheads with minimal loss in speed. Default = True\n",
     "1. (DEPRECATED)  maxSamples Number of cells in the dataset"
    ]
   },


### PR DESCRIPTION
If True, scBonita will use a parallelized local search to speed up the rule inference for large networks (with ~ 100 nodes or more). We suggest setting this to False for smaller networks or for KEGG networks, to reduce memory overheads with minimal loss in speed.